### PR TITLE
Add option for favorites list and quick add button (MOOS-31)

### DIFF
--- a/shuup_wishlist/__init__.py
+++ b/shuup_wishlist/__init__.py
@@ -11,12 +11,17 @@ import shuup.apps
 class AppConfig(shuup.apps.AppConfig):
     name = __name__
     provides = {
+        "admin_shop_form_part": [
+            "shuup_wishlist.configuration.WishlistSettingsFormPart",
+        ],
         "xtheme_plugin": [
             __name__ + ".plugins:WishlistPlugin",
             __name__ + ".plugins:WishlistSmallButtonPlugin",
+            __name__ + ".plugins:WishlistFavoritesButtonPlugin",
         ],
         "customer_dashboard_items": [
             __name__ + '.dashboard_items:WishlistItem',
+            __name__ + '.dashboard_items:FavoritesItem'
         ],
         "xtheme_resource_injection": [__name__ + ".plugins:add_resources"],
         "front_urls": [

--- a/shuup_wishlist/configuration.py
+++ b/shuup_wishlist/configuration.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2019, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import unicode_literals
+
+from django import forms
+from django.utils.translation import ugettext_lazy as _
+
+from shuup import configuration
+from shuup.front.admin_module.forms import (
+    BaseSettingsForm, BaseSettingsFormPart
+)
+
+
+def is_dasbhoard_enabled(shop):
+    return configuration.get(shop, "show_wishlist_on_dashboard", True)
+
+
+def is_favorites_enabled(shop):
+    return configuration.get(shop, "show_favorites_wishlist_on_dashboard", False)
+
+
+class WishlistSettingsForm(BaseSettingsForm):
+    title = _("Wishlist Settings")
+    show_wishlist_on_dashboard = forms.BooleanField(
+        label=_("Show wishlists on dashboard"),
+        help_text=_("Setting this to false will hide wishlists from customer dashboard."),
+        required=False,
+        initial=True
+    )
+    show_favorites_wishlist_on_dashboard = forms.BooleanField(
+        label=_("Show favorites wishlist on dashboard"),
+        help_text=_("Combined with Wishlist Favorites Button plugin show favorites wishlist at dashboard."),
+        required=False,
+        initial=False
+    )
+
+
+class WishlistSettingsFormPart(BaseSettingsFormPart):
+    form = WishlistSettingsForm
+    name = "wishlist_settings"
+    priority = 10

--- a/shuup_wishlist/dashboard_items.py
+++ b/shuup_wishlist/dashboard_items.py
@@ -5,11 +5,15 @@
 #
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
+from django.core.urlresolvers import reverse
 from django.db.models import Count
 from django.utils.translation import ugettext_lazy as _
 
 from shuup.front.utils.dashboard import DashboardItem
 from shuup_wishlist.models import Wishlist
+
+from .configuration import is_dasbhoard_enabled, is_favorites_enabled
+from .favorites import get_favorites_list
 
 
 class WishlistItem(DashboardItem):
@@ -19,6 +23,12 @@ class WishlistItem(DashboardItem):
     view_text = _("Show all")
     _url = "shuup:personal_wishlists"
 
+    def show_on_menu(self):
+        return is_dasbhoard_enabled(self.request.shop)
+
+    def show_on_dashboard(self):
+        return is_dasbhoard_enabled(self.request.shop)
+
     def get_context(self):
         context = super(WishlistItem, self).get_context()
         context["wishlists"] = Wishlist.objects.filter(
@@ -26,3 +36,20 @@ class WishlistItem(DashboardItem):
             shop=self.request.shop
         ).annotate(product_count=Count('products'))[:5]
         return context
+
+
+class FavoritesItem(DashboardItem):
+    title = _("Favorites")
+    icon = "fa fa-heart"
+
+    def show_on_menu(self):
+        return is_favorites_enabled(self.request.shop)
+
+    def show_on_dashboard(self):
+        return False
+
+    @property
+    def url(self):
+        shop = self.request.shop
+        customer = self.request.customer
+        return reverse("shuup:wishlist_detail", kwargs={"pk": get_favorites_list(shop, customer).pk})

--- a/shuup_wishlist/dashboard_items.py
+++ b/shuup_wishlist/dashboard_items.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-# This file is part of Shuup Wishlist.
+# This file is part of Shuup.
 #
-# Copyright (c) 2012-2018, Shoop Commerce Ltd. All rights reserved.
+# Copyright (c) 2012-2019, Shoop Commerce Ltd. All rights reserved.
 #
-# This source code is licensed under the AGPLv3 license found in the
+# This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 from django.core.urlresolvers import reverse
 from django.db.models import Count

--- a/shuup_wishlist/favorites.py
+++ b/shuup_wishlist/favorites.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-# This file is part of Shuup Wishlist.
+# This file is part of Shuup.
 #
-# Copyright (c) 2012-2018, Shoop Commerce Ltd. All rights reserved.
+# Copyright (c) 2012-2019, Shoop Commerce Ltd. All rights reserved.
 #
-# This source code is licensed under the AGPLv3 license found in the
+# This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 from django.utils.translation import ugettext_lazy as _
 

--- a/shuup_wishlist/favorites.py
+++ b/shuup_wishlist/favorites.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup Wishlist.
+#
+# Copyright (c) 2012-2018, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from django.utils.translation import ugettext_lazy as _
+
+from shuup_wishlist.models import Wishlist
+
+
+def get_favorites_list(shop, customer):
+    return Wishlist.objects.get_or_create(
+        shop=shop, customer=customer, name=_("Favorites"))[0]

--- a/shuup_wishlist/forms.py
+++ b/shuup_wishlist/forms.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-# This file is part of Shuup Wishlist.
+# This file is part of Shuup.
 #
-# Copyright (c) 2012-2018, Shoop Commerce Ltd. All rights reserved.
+# Copyright (c) 2012-2019, Shoop Commerce Ltd. All rights reserved.
 #
-# This source code is licensed under the AGPLv3 license found in the
+# This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 from django import forms
 from django.core.exceptions import ValidationError

--- a/shuup_wishlist/models.py
+++ b/shuup_wishlist/models.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-# This file is part of Shuup Wishlist.
+# This file is part of Shuup.
 #
-# Copyright (c) 2012-2018, Shoop Commerce Ltd. All rights reserved.
+# Copyright (c) 2012-2019, Shoop Commerce Ltd. All rights reserved.
 #
-# This source code is licensed under the AGPLv3 license found in the
+# This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 from __future__ import unicode_literals
 

--- a/shuup_wishlist/plugins.py
+++ b/shuup_wishlist/plugins.py
@@ -14,6 +14,8 @@ from django.utils.translation import ugettext_lazy as _
 from shuup.xtheme.resources import add_resource
 from shuup_wishlist.models import Wishlist
 
+from .favorites import get_favorites_list
+
 try:
     from shuup.xtheme import TemplatedPlugin
 except ImportError:
@@ -67,4 +69,27 @@ class WishlistSmallButtonPlugin(TemplatedPlugin):
     def get_context_data(self, context):
         context = super(WishlistSmallButtonPlugin, self).get_context_data(context)
         context["show_text"] = self.config.get("show_text", True)
+        return context
+
+
+class WishlistFavoritesButtonPlugin(TemplatedPlugin):
+    identifier = "shuup_wishlist.wishlist_favorites_button"
+    name = _("Wishlist Favorites Button")
+    template_name = "shuup_wishlist/buttons/favorites_button.jinja"
+    required_context_variables = ['shop_product']
+
+    fields = [
+        ("show_text", forms.BooleanField(
+            label=_("Show text next to icon"),
+            required=False,
+            initial=True,
+        )),
+    ]
+
+    def get_context_data(self, context):
+        context = super(WishlistFavoritesButtonPlugin, self).get_context_data(context)
+        context["show_text"] = self.config.get("show_text", True)
+        shop = context['request'].shop
+        customer = context['request'].customer
+        context["wishlist_id"] = get_favorites_list(shop, customer).pk
         return context

--- a/shuup_wishlist/plugins.py
+++ b/shuup_wishlist/plugins.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-# This file is part of Shuup Wishlist.
+# This file is part of Shuup.
 #
-# Copyright (c) 2012-2018, Shoop Commerce Ltd. All rights reserved.
+# Copyright (c) 2012-2019, Shoop Commerce Ltd. All rights reserved.
 #
-# This source code is licensed under the AGPLv3 license found in the
+# This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 from __future__ import unicode_literals
 

--- a/shuup_wishlist/static_src/js/lib.js
+++ b/shuup_wishlist/static_src/js/lib.js
@@ -120,23 +120,23 @@ window.ShuupWishlist = {
                 var msg = "";
                 if (action === "add") {
                     if (response.created) {
-                        msg = interpolate(gettext("%s added to wishlist!"), [response.product_name]);
+                        msg = interpolate(gettext("%s added successfully!"), [response.product_name]);
                         that.flashMessage("success", msg, "");
                     } else if (response.err) {
                         that.showCreateWishlistModal(shopProductId);
                     } else {
-                        msg = interpolate(gettext("%s is already in wishlist!"), [response.product_name]);
+                        msg = interpolate(gettext("%s is already in list!"), [response.product_name]);
                         that.flashMessage("danger", msg, "");
                     }
                 }
                 else {
                     if (response.removed) {
-                        that.flashMessage("success", gettext("Product removed from wishlist!"), "");
+                        that.flashMessage("success", gettext("Item removed from list!"), "");
                         if (hideElement) {
                             hideElement.hide();
                         }
                     } else {
-                        that.flashMessage("danger", gettext("Error removing product from wishlist. Try again later."), "");
+                        that.flashMessage("danger", gettext("Error removing item from list. Try again later."), "");
                     }
                 }
             },

--- a/shuup_wishlist/templates/shuup_wishlist/buttons/favorites_button.jinja
+++ b/shuup_wishlist/templates/shuup_wishlist/buttons/favorites_button.jinja
@@ -1,0 +1,13 @@
+{% if request.customer %}
+<div>
+    <a
+        type="button"
+        href="#"
+        class="add-to-wishlist"
+        data-shop-product-id="{{ shop_product.id }}"
+        data-wishlist-id="{{ wishlist_id }}"
+        title="{% trans %}Add to favorites{% endtrans %}">
+        <i class="fa fa-heart"></i>{% if show_text %} {% trans %}Add to favorites{% endtrans %}{% endif %}
+    </a>
+</div>
+{% endif %}

--- a/shuup_wishlist/templates/shuup_wishlist/customer_wishlist_detail.jinja
+++ b/shuup_wishlist/templates/shuup_wishlist/customer_wishlist_detail.jinja
@@ -5,6 +5,8 @@
 {% endif %}
 {% block title -%}{{ customer_wishlist.name }}{%- endblock %}
 
+{% set item_count = customer_wishlist.products.count() %}
+
 {% block breadcrumb %}
     <ol class="breadcrumb">
         <li><a href="/">{% trans %}Home{% endtrans %}</a></li>
@@ -16,20 +18,20 @@
 {% macro render_wishlist() %}
 <h1>
     {{ customer_wishlist.name }}
-    {% if is_owner %}
+    {% if is_owner and item_count %}
         <div class="pull-right">
             <form id="delete-customer-wishlist"
                method="post"
                action="{{ url("shuup:delete_wishlist", pk=customer_wishlist.pk) }}">
                 {% csrf_token %}
                 <button class="btn btn-primary">
-                    <i class="fa fa-trash"></i> {% trans %}Delete Wishlist{% endtrans %}
+                    <i class="fa fa-trash"></i> {% trans %}Delete{% endtrans %}
                 </button>
             </form>
         </div>
     {% endif %}
 </h1>
-{% if customer_wishlist.products.count() %}
+{% if item_count %}
 {% if is_owner %}
 <div class="row">
     <div class="col-md-12">
@@ -72,8 +74,7 @@
                             <div class="btn-vertical">
                                 <a href="{{ product_url }}" class="btn btn-primary">
                                     <i class="fa fa-search"></i>
-                                    {% trans %}View Product{% endtrans %}
-                                    <i class="fa fa-angle-double-right"></i>
+                                    {% trans %}View{% endtrans %}
                                 </a>
                                 {% if is_owner %}
                                     <form method="POST"
@@ -99,7 +100,7 @@
 </div>
 {% else %}
     <p class="lead">
-        <i class="fa fa-info-circle text-info"></i> {{ _("No products found.") }}
+        <i class="fa fa-info-circle text-info"></i> {{ _("This list is empty.") }}
     </p>
 {% endif %}
 {% endmacro %}

--- a/shuup_wishlist/urls.py
+++ b/shuup_wishlist/urls.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-# This file is part of Shuup Wishlist.
+# This file is part of Shuup.
 #
-# Copyright (c) 2012-2018, Shoop Commerce Ltd. All rights reserved.
+# Copyright (c) 2012-2019, Shoop Commerce Ltd. All rights reserved.
 #
-# This source code is licensed under the AGPLv3 license found in the
+# This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 from django.conf.urls import url
 from django.contrib.auth.decorators import login_required

--- a/shuup_wishlist/views.py
+++ b/shuup_wishlist/views.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-# This file is part of Shuup Wishlist.
+# This file is part of Shuup.
 #
-# Copyright (c) 2012-2018, Shoop Commerce Ltd. All rights reserved.
+# Copyright (c) 2012-2019, Shoop Commerce Ltd. All rights reserved.
 #
-# This source code is licensed under the AGPLv3 license found in the
+# This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 from django.contrib import messages
 from django.core.urlresolvers import reverse_lazy

--- a/shuup_wishlist_tests/conftest.py
+++ b/shuup_wishlist_tests/conftest.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-# This file is part of Shuup Wishlist.
+# This file is part of Shuup.
 #
-# Copyright (c) 2012-2018, Shoop Commerce Ltd. All rights reserved.
+# Copyright (c) 2012-2019, Shoop Commerce Ltd. All rights reserved.
 #
-# This source code is licensed under the AGPLv3 license found in the
+# This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 import pytest
 

--- a/shuup_wishlist_tests/fixtures.py
+++ b/shuup_wishlist_tests/fixtures.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-# This file is part of Shuup Wishlist.
+# This file is part of Shuup.
 #
-# Copyright (c) 2012-2018, Shoop Commerce Ltd. All rights reserved.
+# Copyright (c) 2012-2019, Shoop Commerce Ltd. All rights reserved.
 #
-# This source code is licensed under the AGPLv3 license found in the
+# This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 import pytest
 

--- a/shuup_wishlist_tests/settings.py
+++ b/shuup_wishlist_tests/settings.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-# This file is part of Shuup Wishlist.
+# This file is part of Shuup.
 #
-# Copyright (c) 2012-2018, Shoop Commerce Ltd. All rights reserved.
+# Copyright (c) 2012-2019, Shoop Commerce Ltd. All rights reserved.
 #
-# This source code is licensed under the AGPLv3 license found in the
+# This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 import os
 import tempfile

--- a/shuup_wishlist_tests/test_forms.py
+++ b/shuup_wishlist_tests/test_forms.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-# This file is part of Shuup Wishlist.
+# This file is part of Shuup.
 #
-# Copyright (c) 2012-2018, Shoop Commerce Ltd. All rights reserved.
+# Copyright (c) 2012-2019, Shoop Commerce Ltd. All rights reserved.
 #
-# This source code is licensed under the AGPLv3 license found in the
+# This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 import pytest
 

--- a/shuup_wishlist_tests/test_plugin.py
+++ b/shuup_wishlist_tests/test_plugin.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-# This file is part of Shuup Wishlist.
+# This file is part of Shuup.
 #
-# Copyright (c) 2012-2018, Shoop Commerce Ltd. All rights reserved.
+# Copyright (c) 2012-2019, Shoop Commerce Ltd. All rights reserved.
 #
-# This source code is licensed under the AGPLv3 license found in the
+# This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 import pytest
 

--- a/shuup_wishlist_tests/test_views.py
+++ b/shuup_wishlist_tests/test_views.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-# This file is part of Shuup Wishlist.
+# This file is part of Shuup.
 #
-# Copyright (c) 2012-2018, Shoop Commerce Ltd. All rights reserved.
+# Copyright (c) 2012-2019, Shoop Commerce Ltd. All rights reserved.
 #
-# This source code is licensed under the AGPLv3 license found in the
+# This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 import json
 


### PR DESCRIPTION
- Add option to show favorites wishlist at dashboard menu
- Add option to quick add products to favorites wishlist
- Tune texts so that we are not expecting that it is products we add to lists
- Also there is now option to only show favorites option as a lightweight wishlist